### PR TITLE
Fix issue of several accounts with same usernames

### DIFF
--- a/rootme/rank.py
+++ b/rootme/rank.py
@@ -38,14 +38,13 @@ def rank(args: argparse.Namespace, cookie: str) -> None:
 
         users: Dict[str, Searchresult] = search_user(username, cookies)
 
-        userid = ""
-        # Parse API search results in order to find the correct user
+        userids = []
+        # Parse API search results in order to find the correct users
         for user in users:
             if users[user]["nom"] == username:
-                userid = users[user]["id_auteur"]
-                break
+                userids.append(users[user]["id_auteur"])
 
-        if not userid:
+        if not userids:
             raise ValueError(
                 (
                     "User %s not found in 50 first search terms."
@@ -54,14 +53,17 @@ def rank(args: argparse.Namespace, cookie: str) -> None:
                 username,
             )
 
-        userinfo = get_user_info(userid, cookies)
+        for userid in userids:
+            userinfo = get_user_info(userid, cookies)
+            if userinfo is None:
+                continue
 
-        print(
-            f"[{Fore.GREEN}+{Style.RESET_ALL}] "
-            f"{userinfo['nom']:<{max_len_user + 2}} "
-            f"Score: {userinfo['score']:<6} "
-            f"Position: {userinfo['position']}"
-        )
+            print(
+                f"[{Fore.GREEN}+{Style.RESET_ALL}] "
+                f"{userinfo['nom']:<{max_len_user + 2}} "
+                f"Score: {userinfo['score']:<6} "
+                f"Position: {userinfo['position']}"
+            )
 
 
 def display_ranking(args: argparse.Namespace, cookie: str) -> None:
@@ -106,6 +108,8 @@ def display_ranking(args: argparse.Namespace, cookie: str) -> None:
 
         userid = ranking[entry]["id_auteur"]
         userinfo = get_user_info(userid, cookies)
+        if userinfo is None:
+            continue
 
         print(
             f"{Fore.YELLOW}{ranking[entry]['place']:>4}{Style.RESET_ALL}. "

--- a/rootme/utils.py
+++ b/rootme/utils.py
@@ -1,7 +1,7 @@
 """root-me.org API utilities."""
 
 import json
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 
@@ -49,7 +49,7 @@ def search_user(
     return results
 
 
-def get_user_info(userid: str, cookies: Dict[str, str]) -> Userinfo:
+def get_user_info(userid: str, cookies: Dict[str, str]) -> Optional[Userinfo]:
     """Get user information based on userid.
 
     Parameters
@@ -69,9 +69,8 @@ def get_user_info(userid: str, cookies: Dict[str, str]) -> Userinfo:
     r = requests.get(url, cookies=cookies)
 
     if r.status_code != 200:
-        raise ValueError(
-            "Cannot get info about user %s. Error %s", userid, r.status_code,
-        )
+        print(f"Cannot get info about user %s. Error %s" % (userid, r.status_code))
+        return
 
     # Load results in intermediate variable in order to check type consistency
     # Mypy is not able to infer type directly from JSON data. Typing is more


### PR DESCRIPTION
Before:
```
rootme rank -u zTeeed
Traceback (most recent call last):
  File "/usr/bin/rootme", line 11, in <module>
    load_entry_point('rootme==1.0.0', 'console_scripts', 'rootme')()
  File "/usr/lib/python3.8/site-packages/rootme/__main__.py", line 123, in main
    rank(args, cookie)
  File "/usr/lib/python3.8/site-packages/rootme/rank.py", line 57, in rank
    userinfo = get_user_info(userid, cookies)
  File "/usr/lib/python3.8/site-packages/rootme/utils.py", line 73, in get_user_info
    raise ValueError(
ValueError: ('Cannot get info about user %s. Error %s', '108022', 404)
```

but response content is:
```
{'0': {'id_auteur': '108022', 'nom': 'zTeeed'}, '1': {'id_auteur': '115405', 'nom': 'zTeeed'}}
```

Now:
```
rootme rank -u zTeeed
Cannot get info about user 108022. Error 404
[+] zTeeed   Score: 5875   Position: 297
```